### PR TITLE
Imports/Use a cache to store previous calls to go/packages

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,8 +14,8 @@ import (
 
 	"runtime/debug"
 
-	"github.com/ikgo/gocode/internal/gbimporter"
-	"github.com/ikgo/gocode/internal/suggest"
+	"github.com/achansen121/gocode/internal/gbimporter"
+	"github.com/achansen121/gocode/internal/suggest"
 )
 
 func doClient() {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,0 @@
-module github.com/ikgo/gocode
-
-require (
-	golang.org/x/tools v0.0.0-20180831211245-7ca132754999
-)

--- a/internal/gbimporter/context.go
+++ b/internal/gbimporter/context.go
@@ -4,7 +4,7 @@ import "go/build"
 
 // PackedContext is a copy of build.Context without the func fields.
 //
-// TODO(ikgo): Not sure this belongs here.
+// TODO(achansen121): Not sure this belongs here.
 type PackedContext struct {
 	GOARCH        string
 	GOOS          string

--- a/internal/lookdot/lookdot_test.go
+++ b/internal/lookdot/lookdot_test.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/ikgo/gocode/internal/lookdot"
+	"github.com/achansen121/gocode/internal/lookdot"
 )
 
 const src = `
@@ -110,7 +110,7 @@ func TestWalk(t *testing.T) {
 
 		var got []string
 		visitor := func(obj types.Object) {
-			// TODO(ikgo): Should Walk be responsible
+			// TODO(achansen121): Should Walk be responsible
 			// for filtering out inaccessible objects?
 			if obj.Exported() || obj.Pkg() == pkg {
 				got = append(got, obj.Name())

--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -176,7 +176,7 @@ func (b *candidateCollector) appendObject(obj types.Object) {
 		}
 	}
 
-	// TODO(ikgo): Reconsider this functionality.
+	// TODO(achansen121): Reconsider this functionality.
 	if b.filter != nil && !b.filter(obj) {
 		return
 	}

--- a/internal/suggest/formatters_test.go
+++ b/internal/suggest/formatters_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/ikgo/gocode/internal/suggest"
+	"github.com/achansen121/gocode/internal/suggest"
 )
 
 func TestFormatters(t *testing.T) {
-	// TODO(ikgo): More comprehensive test.
+	// TODO(achansen121): More comprehensive test.
 
 	num := len("client")
 	candidates := []suggest.Candidate{{

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ikgo/gocode/internal/lookdot"
+	"github.com/achansen121/gocode/internal/lookdot"
 )
 
 type Config struct {
@@ -177,7 +177,7 @@ func (c *Config) findOtherPackageFiles(filename, pkgName string) []string {
 	}
 	isTestFile := strings.HasSuffix(file, "_test.go")
 
-	// TODO(ikgo): Use go/build.(*Context).MatchFile or
+	// TODO(achansen121): Use go/build.(*Context).MatchFile or
 	// something to properly handle build tags?
 	var out []string
 	for _, dent := range dents {

--- a/internal/suggest/suggest_test.go
+++ b/internal/suggest/suggest_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ikgo/gocode/internal/suggest"
+	"github.com/achansen121/gocode/internal/suggest"
 )
 
 func TestRegress(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -13,8 +13,8 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/ikgo/gocode/internal/gbimporter"
-	"github.com/ikgo/gocode/internal/suggest"
+	"github.com/achansen121/gocode/internal/gbimporter"
+	"github.com/achansen121/gocode/internal/suggest"
 )
 
 func doServer() {


### PR DESCRIPTION
Use a cache to store previous calls to go/packages so that it returns faster on the 2nd call.